### PR TITLE
bugfix to enable creation of new profiles even when there are already (unrelated) profiles in config file.

### DIFF
--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -42,12 +42,15 @@ def test_create_new_profile_dryrun(Popen):
 
 
 @patch('xprofile.xrandr.Popen')
-def test_create_existing_profile(Popen):
+@patch('xprofile.xrandr.Screen.get_edid')
+def test_create_existing_profile(edid, Popen):
     with open('test/docked.txt', 'rb') as file:
         xrandr_stdout = file.read()
 
     Popen.return_value.communicate.return_value = (xrandr_stdout, None)
     Popen.return_value.wait.return_value = 0
+
+    edid.return_value = 'c2989146488f57fa9dc5f7efc263b0fd1'
 
     retval = main(['--config', 'test/xprofilerc_both_example', 'create', 'laptop'])
 
@@ -57,14 +60,14 @@ def test_create_existing_profile(Popen):
 
 
 @patch('xprofile.xrandr.Popen')
-def test_create_new_profile_when_other_profiles_exists(Popen):
-    with open('test/docked.txt', 'rb') as file:
+def test_create_new_profile_when_other_profiles_exists_dryrun(Popen):
+    with open('test/laptop.txt', 'rb') as file:
         xrandr_stdout = file.read()
 
     Popen.return_value.communicate.return_value = (xrandr_stdout, None)
     Popen.return_value.wait.return_value = 0
 
-    retval = main(['--config', 'test/xprofilerc_docked_only_example', 'create', 'not_in_config'])
+    retval = main(['--config', 'test/xprofilerc_docked_only_example', 'create', 'not_in_config', '--dry-run'])
 
     assert retval == 0
     assert Popen.called

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -3,11 +3,11 @@ import tempfile
 
 from mock import patch
 
-from xprofile.xrandr import Xrandr
 from xprofile.__main__ import main
 from distutils.spawn import find_executable
 
 xrandr_bin = find_executable('xrandr')
+
 
 @patch('xprofile.xrandr.Popen')
 def test_create_new_profile(Popen):
@@ -49,14 +49,30 @@ def test_create_existing_profile(Popen):
     Popen.return_value.communicate.return_value = (xrandr_stdout, None)
     Popen.return_value.wait.return_value = 0
 
-    retval = main(['--config', 'test/xprofilerc_example', 'create', 'laptop'])
+    retval = main(['--config', 'test/xprofilerc_both_example', 'create', 'laptop'])
 
     assert retval == 1
     assert Popen.called
     assert Popen.call_args[0][0] == [xrandr_bin, '--verbose']
 
+
+@patch('xprofile.xrandr.Popen')
+def test_create_new_profile_when_other_profiles_exists(Popen):
+    with open('test/docked.txt', 'rb') as file:
+        xrandr_stdout = file.read()
+
+    Popen.return_value.communicate.return_value = (xrandr_stdout, None)
+    Popen.return_value.wait.return_value = 0
+
+    retval = main(['--config', 'test/xprofilerc_docked_only_example', 'create', 'not_in_config'])
+
+    assert retval == 0
+    assert Popen.called
+    assert Popen.call_args[0][0] == [xrandr_bin, '--verbose']
+
+
 def test_list():
-    main(['--config', 'test/xprofilerc_example', 'list'])
+    main(['--config', 'test/xprofilerc_both_example', 'list'])
 
 
 @patch('xprofile.xrandr.Popen')
@@ -67,7 +83,7 @@ def test_current(Popen):
     Popen.return_value.communicate.return_value = (xrandr_stdout, None)
     Popen.return_value.wait.return_value = 0
 
-    retval = main(['--config', 'test/xprofilerc_example', 'current'])
+    retval = main(['--config', 'test/xprofilerc_both_example', 'current'])
 
     assert retval == 0
     assert Popen.called
@@ -78,7 +94,7 @@ def test_activate_profile(Popen):
     Popen.return_value.communicate.return_value = (b'', None)
     Popen.return_value.wait.return_value = 0
 
-    retval = main(['--config', 'test/xprofilerc_example', 'activate', 'docked'])
+    retval = main(['--config', 'test/xprofilerc_both_example', 'activate', 'docked'])
 
     assert retval == 0
     assert Popen.called
@@ -91,7 +107,7 @@ def test_activate_profile(Popen):
 
 
 def test_activate_profile_nonexistent():
-    retval = main(['--config', 'test/xprofilerc_example', 'activate', 'nonexistent'])
+    retval = main(['--config', 'test/xprofilerc_both_example', 'activate', 'nonexistent'])
 
     assert retval == 1
 
@@ -104,7 +120,7 @@ def test_activate_profile_auto(Popen):
     Popen.return_value.communicate.return_value = (xrandr_stdout, None)
     Popen.return_value.wait.return_value = 0
 
-    retval = main(['--config', 'test/xprofilerc_example', 'auto'])
+    retval = main(['--config', 'test/xprofilerc_both_example', 'auto'])
 
     assert retval == 0
     assert Popen.called
@@ -119,7 +135,7 @@ def test_activate_profile_auto__dryrun(Popen):
     Popen.return_value.communicate.return_value = (xrandr_stdout, None)
     Popen.return_value.wait.return_value = 0
 
-    retval = main(['--config', 'test/xprofilerc_example', 'auto', '--dry-run'])
+    retval = main(['--config', 'test/xprofilerc_both_example', 'auto', '--dry-run'])
 
     assert retval == 0
     assert Popen.called
@@ -134,7 +150,7 @@ def test_activate_profile_auto_nonexistent(Popen):
     Popen.return_value.communicate.return_value = (xrandr_stdout, None)
     Popen.return_value.wait.return_value = 0
 
-    retval = main(['--config', 'test/xprofilerc_example', 'auto'])
+    retval = main(['--config', 'test/xprofilerc_both_example', 'auto'])
 
     assert retval == 0
     assert Popen.called

--- a/test/xprofilerc_both_example
+++ b/test/xprofilerc_both_example
@@ -1,0 +1,13 @@
+[DEFAULT]
+display = :0
+args = --auto
+
+[laptop]
+name = on the go
+edid = cfdee1377d86e245f2d187082f7a504a
+args = --auto
+
+[docked]
+name = my desk
+edid = c2989146488f57fa9dc5f7efc263b0fd1
+args = --output LVDS1 --off --output DP2 --mode 1920x1080 --pos 0x500 --primary --output HDMI3 --mode 1920x1080 --rotate left --pos 1930x0

--- a/test/xprofilerc_docked_only_example
+++ b/test/xprofilerc_docked_only_example
@@ -1,0 +1,14 @@
+[DEFAULT]
+display = :0
+args = --auto
+
+[docked]
+name = my desk
+edid = c2989146488f57fa9dc5f7efc263b0fd1
+args = --output LVDS1 --off --output DP2 --mode 1920x1080 --pos 0x500 --primary --output HDMI3 --mode 1920x1080 --rotate left --pos 1930x0
+
+[not_in_config]
+name = not_in_config's xrandr profile
+edid = c2989146488f57fa9dc5f7efc263b0fd
+args = --output LVDS1 --off --output HDMI3 --mode 1920x1080 --pos 1930x0 --rotate left --output DP2 --primary --mode 1920x1080 --pos 0x500
+

--- a/test/xprofilerc_docked_only_example
+++ b/test/xprofilerc_docked_only_example
@@ -6,9 +6,3 @@ args = --auto
 name = my desk
 edid = c2989146488f57fa9dc5f7efc263b0fd1
 args = --output LVDS1 --off --output DP2 --mode 1920x1080 --pos 0x500 --primary --output HDMI3 --mode 1920x1080 --rotate left --pos 1930x0
-
-[not_in_config]
-name = not_in_config's xrandr profile
-edid = c2989146488f57fa9dc5f7efc263b0fd
-args = --output LVDS1 --off --output HDMI3 --mode 1920x1080 --pos 1930x0 --rotate left --output DP2 --primary --mode 1920x1080 --pos 0x500
-

--- a/test/xprofilerc_example
+++ b/test/xprofilerc_example
@@ -1,3 +1,0 @@
-[DEFAULT]
-display = :0
-args = --auto

--- a/test/xprofilerc_example
+++ b/test/xprofilerc_example
@@ -1,13 +1,3 @@
 [DEFAULT]
 display = :0
 args = --auto
-
-[laptop]
-name = on the go
-edid = cfdee1377d86e245f2d187082f7a504a
-args = --auto
-
-[docked]
-name = my desk
-edid = c2989146488f57fa9dc5f7efc263b0fd1
-args = --output LVDS1 --off --output DP2 --mode 1920x1080 --pos 0x500 --primary --output HDMI3 --mode 1920x1080 --rotate left --pos 1930x0

--- a/xprofile/__main__.py
+++ b/xprofile/__main__.py
@@ -108,8 +108,9 @@ def create_profile(args, config):
     current_edid = screen.get_edid()
 
     for profile in config.sections():
-        log.error('A profile `{0}` already exists for EDID `{1}`.'.format(profile, current_edid))
-        return 1
+        if config.get(profile, 'edid') == current_edid:
+            log.error('A profile `{0}` already exists for EDID `{1}`.'.format(profile, current_edid))
+            return 1
 
     name = args.description or '{0}\'s xrandr profile'.format(args.profile)
     xrandr_args = ' '.join(screen.get_xrandr_options())


### PR DESCRIPTION
fixed problem where you can't create profiles if there is already a profile in config file. This did not needed to be with same edid. Also added a test to check for this case so it won't happen in the future.
